### PR TITLE
Issue 3: Add isolated hello-web API gateway path

### DIFF
--- a/apps/hello-web/deploy.yaml
+++ b/apps/hello-web/deploy.yaml
@@ -1,0 +1,42 @@
+# apps/hello-web/deploy.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitops-lab
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-web
+  namespace: gitops-lab
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hello-web
+  template:
+    metadata:
+      labels:
+        app: hello-web
+      annotations:
+        consul.hashicorp.com/connect-inject: "true"
+        consul.hashicorp.com/service-name: "hello-web"
+    spec:
+      containers:
+        - name: web
+          image: nginxdemos/hello:plain-text
+          ports:
+            - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-web
+  namespace: gitops-lab
+spec:
+  selector:
+    app: hello-web
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80

--- a/apps/hello-web/intentions.yaml
+++ b/apps/hello-web/intentions.yaml
@@ -1,0 +1,13 @@
+# apps/hello-web/intentions.yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceIntentions
+metadata:
+  name: lab-api-gateway-to-hello-web
+  namespace: gitops-lab
+spec:
+  destination:
+    name: hello-web
+  sources:
+    - name: lab-api-gateway
+      namespace: default
+      action: allow

--- a/apps/hello-web/referencegrant.yaml
+++ b/apps/hello-web/referencegrant.yaml
@@ -1,0 +1,15 @@
+# apps/hello-web/referencegrant.yaml
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-consul-route-to-hello-web
+  namespace: gitops-lab
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: consul
+  to:
+    - group: ""
+      kind: Service
+      name: hello-web

--- a/platform/consul/api-gateway/gateway.yaml
+++ b/platform/consul/api-gateway/gateway.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: lab-api-gateway
+  namespace: consul
+spec:
+  gatewayClassName: consul
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same

--- a/platform/consul/api-gateway/routes/hello-web-route.yaml
+++ b/platform/consul/api-gateway/routes/hello-web-route.yaml
@@ -1,0 +1,22 @@
+# platform/consul/api-gateway/routes/hello-web-route.yaml
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: hello-web-route
+  namespace: consul
+spec:
+  hostnames:
+    - hello.lab.test
+  parentRefs:
+    - name: lab-api-gateway
+      sectionName: http
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - kind: Service
+          name: hello-web
+          namespace: gitops-lab
+          port: 80


### PR DESCRIPTION
Adds hello-web test app, HTTPRoute, ReferenceGrant, and ServiceIntentions for isolated API Gateway validation on hello.lab.test.